### PR TITLE
Add volume size variable to asg. Bump concourse to 50GB. Fixes #47.

### DIFF
--- a/concourse/concourse.tf
+++ b/concourse/concourse.tf
@@ -69,7 +69,7 @@ variable "instance_key" {
 
 variable "instance_ami" {
   description = "CoreOS AMI ID for Concourse instances."
-  default     = "ami-38ef0041"
+  default     = "ami-bbaf0ac2"
 }
 
 variable "image_repository" {
@@ -79,7 +79,7 @@ variable "image_repository" {
 
 variable "image_version" {
   description = "Concourse image version."
-  default     = "3.5.0"
+  default     = "3.6.0"
 }
 
 variable "atc_count" {
@@ -355,16 +355,17 @@ data "aws_iam_policy_document" "worker" {
 module "worker" {
   source = "../ec2/asg"
 
-  prefix          = "${var.prefix}-worker"
-  user_data       = "${data.template_file.worker.rendered}"
-  vpc_id          = "${var.vpc_id}"
-  subnet_ids      = "${var.subnet_ids}"
-  instance_policy = "${data.aws_iam_policy_document.worker.json}"
-  instance_count  = "${var.worker_count}"
-  instance_type   = "${var.worker_type}"
-  instance_ami    = "${var.instance_ami}"
-  instance_key    = "${var.instance_key}"
-  tags            = "${var.tags}"
+  prefix               = "${var.prefix}-worker"
+  user_data            = "${data.template_file.worker.rendered}"
+  vpc_id               = "${var.vpc_id}"
+  subnet_ids           = "${var.subnet_ids}"
+  instance_policy      = "${data.aws_iam_policy_document.worker.json}"
+  instance_count       = "${var.worker_count}"
+  instance_type        = "${var.worker_type}"
+  instance_volume_size = "50"
+  instance_ami         = "${var.instance_ami}"
+  instance_key         = "${var.instance_key}"
+  tags                 = "${var.tags}"
 }
 
 resource "aws_security_group_rule" "worker_ingress_tsa" {

--- a/ec2/asg/asg.tf
+++ b/ec2/asg/asg.tf
@@ -24,6 +24,11 @@ variable "instance_type" {
   default     = "t2.micro"
 }
 
+variable "instance_volume_size" {
+  description = "Size of the root block device."
+  default     = "8"
+}
+
 variable "instance_count" {
   description = "Desired (and minimum) number of instances."
   default     = "1"
@@ -42,7 +47,8 @@ variable "instance_key" {
 // HACK: Count issues, but we want this to be optional.
 variable "instance_policy" {
   description = "Optional: A policy document which is applied to the instance profile."
-  default     = <<EOF
+
+  default = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -119,6 +125,12 @@ resource "aws_launch_configuration" "main" {
   image_id             = "${var.instance_ami}"
   key_name             = "${var.instance_key}"
   user_data            = "${var.user_data}"
+
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = "${var.instance_volume_size}"
+    delete_on_termination = true
+  }
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Also bumping CoreOS version along with Concourse image version.