### PR TITLE
Concourse binary solution

### DIFF
--- a/concourse/concourse.tf
+++ b/concourse/concourse.tf
@@ -73,23 +73,13 @@ variable "instance_key" {
 }
 
 variable "concourse_version" {
-  description = "CoreOS AMI ID for Concourse instances."
+  description = "Version of Concourse to download/run."
   default     = "3.6.0"
 }
 
 variable "instance_ami" {
-  description = "CoreOS AMI ID for Concourse instances."
-  default     = "ami-bbaf0ac2"
-}
-
-variable "image_repository" {
-  description = "Concourse image repository."
-  default     = "concourse/concourse"
-}
-
-variable "image_version" {
-  description = "Concourse image version."
-  default     = "3.6.0"
+  description = "Ubuntu AMI ID for Concourse instances."
+  default     = "ami-add175d4"
 }
 
 variable "atc_count" {
@@ -219,23 +209,22 @@ data "template_file" "atc" {
   template = "${file("${path.module}/config/atc.yml")}"
 
   vars {
-    concourse_download_url          = "https://github.com/concourse/concourse/releases/download/v${var.concourse_version}/concourse_linux_amd64"
-    systemd_cloudwatch_download_url = "https://github.com/advantageous/systemd-cloud-watch/releases/download/v0.2.1/systemd-cloud-watch_linux"
-    github_client_id                = "${var.github_client_id}"
-    github_client_secret            = "${var.github_client_secret}"
-    github_users                    = "${join(",", "${var.github_users}")}"
-    concourse_web_host              = "https://${var.domain}:${var.web_port}"
-    concourse_postgres_source       = "${module.postgres.connection_string}"
-    log_group_name                  = "${aws_cloudwatch_log_group.atc.name}"
-    log_group_region                = "${data.aws_region.current.name}"
-    log_level                       = "${var.log_level}"
-    tsa_host_key                    = "${file("${var.concourse_keys}/tsa_host_key")}"
-    session_signing_key             = "${file("${var.concourse_keys}/session_signing_key")}"
-    authorized_worker_keys          = "${file("${var.concourse_keys}/authorized_worker_keys")}"
-    vault_url                       = "${var.vault_url}"
-    vault_client_token              = "${var.vault_client_token}"
-    encryption_key                  = "${var.encryption_key}"
-    old_encryption_key              = "${var.old_encryption_key}"
+    concourse_download_url    = "https://github.com/concourse/concourse/releases/download/v${var.concourse_version}/concourse_linux_amd64"
+    github_client_id          = "${var.github_client_id}"
+    github_client_secret      = "${var.github_client_secret}"
+    github_users              = "${join(",", "${var.github_users}")}"
+    concourse_web_host        = "https://${var.domain}:${var.web_port}"
+    concourse_postgres_source = "${module.postgres.connection_string}"
+    log_group_name            = "${aws_cloudwatch_log_group.atc.name}"
+    log_group_region          = "${data.aws_region.current.name}"
+    log_level                 = "${var.log_level}"
+    tsa_host_key              = "${file("${var.concourse_keys}/tsa_host_key")}"
+    session_signing_key       = "${file("${var.concourse_keys}/session_signing_key")}"
+    authorized_worker_keys    = "${file("${var.concourse_keys}/authorized_worker_keys")}"
+    vault_url                 = "${var.vault_url}"
+    vault_client_token        = "${var.vault_client_token}"
+    encryption_key            = "${var.encryption_key}"
+    old_encryption_key        = "${var.old_encryption_key}"
   }
 }
 
@@ -249,6 +238,7 @@ data "aws_iam_policy_document" "atc" {
 
     actions = [
       "logs:CreateLogStream",
+      "logs:CreateLogGroup",
       "logs:PutLogEvents",
     ]
   }
@@ -277,7 +267,7 @@ module "atc" {
   instance_policy = "${data.aws_iam_policy_document.atc.json}"
   instance_count  = "${var.atc_count}"
   instance_type   = "${var.atc_type}"
-  instance_ami    = "ami-add175d4"
+  instance_ami    = "${var.instance_ami}"
   instance_key    = "${var.instance_key}"
   tags            = "${var.tags}"
 }
@@ -319,15 +309,14 @@ data "template_file" "worker" {
   template = "${file("${path.module}/config/worker.yml")}"
 
   vars {
-    image_version      = "${var.image_version}"
-    image_repository   = "${var.image_repository}"
-    concourse_tsa_host = "${module.internal_elb.dns_name}"
-    log_group_name     = "${aws_cloudwatch_log_group.worker.name}"
-    log_group_region   = "${data.aws_region.current.name}"
-    log_level          = "${var.log_level}"
-    worker_key         = "${file("${var.concourse_keys}/worker_key")}"
-    pub_worker_key     = "${file("${var.concourse_keys}/worker_key.pub")}"
-    pub_tsa_host_key   = "${file("${var.concourse_keys}/tsa_host_key.pub")}"
+    concourse_download_url = "https://github.com/concourse/concourse/releases/download/v${var.concourse_version}/concourse_linux_amd64"
+    concourse_tsa_host     = "${module.internal_elb.dns_name}"
+    log_group_name         = "${aws_cloudwatch_log_group.worker.name}"
+    log_group_region       = "${data.aws_region.current.name}"
+    log_level              = "${var.log_level}"
+    worker_key             = "${file("${var.concourse_keys}/worker_key")}"
+    pub_worker_key         = "${file("${var.concourse_keys}/worker_key.pub")}"
+    pub_tsa_host_key       = "${file("${var.concourse_keys}/tsa_host_key.pub")}"
   }
 }
 
@@ -341,6 +330,7 @@ data "aws_iam_policy_document" "worker" {
 
     actions = [
       "logs:CreateLogStream",
+      "logs:CreateLogGroup",
       "logs:PutLogEvents",
     ]
   }

--- a/concourse/concourse.tf
+++ b/concourse/concourse.tf
@@ -72,6 +72,11 @@ variable "instance_key" {
   default     = ""
 }
 
+variable "concourse_version" {
+  description = "CoreOS AMI ID for Concourse instances."
+  default     = "3.6.0"
+}
+
 variable "instance_ami" {
   description = "CoreOS AMI ID for Concourse instances."
   default     = "ami-bbaf0ac2"
@@ -214,25 +219,23 @@ data "template_file" "atc" {
   template = "${file("${path.module}/config/atc.yml")}"
 
   vars {
-    image_version             = "${var.image_version}"
-    image_repository          = "${var.image_repository}"
-    github_client_id          = "${var.github_client_id}"
-    github_client_secret      = "${var.github_client_secret}"
-    github_users              = "${join(",", "${var.github_users}")}"
-    concourse_web_host        = "https://${var.domain}:${var.web_port}"
-    concourse_postgres_source = "${module.postgres.connection_string}"
-    log_group_name            = "${aws_cloudwatch_log_group.atc.name}"
-    log_group_region          = "${data.aws_region.current.name}"
-    log_level                 = "${var.log_level}"
-    tsa_host_key              = "${file("${var.concourse_keys}/tsa_host_key")}"
-    session_signing_key       = "${file("${var.concourse_keys}/session_signing_key")}"
-    authorized_worker_keys    = "${file("${var.concourse_keys}/authorized_worker_keys")}"
-    atc_port                  = "${var.atc_port}"
-    tsa_port                  = "${var.tsa_port}"
-    vault_url                 = "${var.vault_url}"
-    vault_client_token        = "${var.vault_client_token}"
-    encryption_key            = "${var.encryption_key}"
-    old_encryption_key        = "${var.old_encryption_key}"
+    concourse_download_url          = "https://github.com/concourse/concourse/releases/download/v${var.concourse_version}/concourse_linux_amd64"
+    systemd_cloudwatch_download_url = "https://github.com/advantageous/systemd-cloud-watch/releases/download/v0.2.1/systemd-cloud-watch_linux"
+    github_client_id                = "${var.github_client_id}"
+    github_client_secret            = "${var.github_client_secret}"
+    github_users                    = "${join(",", "${var.github_users}")}"
+    concourse_web_host              = "https://${var.domain}:${var.web_port}"
+    concourse_postgres_source       = "${module.postgres.connection_string}"
+    log_group_name                  = "${aws_cloudwatch_log_group.atc.name}"
+    log_group_region                = "${data.aws_region.current.name}"
+    log_level                       = "${var.log_level}"
+    tsa_host_key                    = "${file("${var.concourse_keys}/tsa_host_key")}"
+    session_signing_key             = "${file("${var.concourse_keys}/session_signing_key")}"
+    authorized_worker_keys          = "${file("${var.concourse_keys}/authorized_worker_keys")}"
+    vault_url                       = "${var.vault_url}"
+    vault_client_token              = "${var.vault_client_token}"
+    encryption_key                  = "${var.encryption_key}"
+    old_encryption_key              = "${var.old_encryption_key}"
   }
 }
 
@@ -274,7 +277,7 @@ module "atc" {
   instance_policy = "${data.aws_iam_policy_document.atc.json}"
   instance_count  = "${var.atc_count}"
   instance_type   = "${var.atc_type}"
-  instance_ami    = "${var.instance_ami}"
+  instance_ami    = "ami-add175d4"
   instance_key    = "${var.instance_key}"
   tags            = "${var.tags}"
 }

--- a/concourse/config/atc.yml
+++ b/concourse/config/atc.yml
@@ -19,25 +19,42 @@ write_files:
     owner: "root"
     encoding: base64
     content: ${base64encode(authorized_worker_keys)}
-  - path: "/usr/local/etc/systemd-cloudwatch-config"
+  - path: "/etc/rsyslog.d/concourse.conf"
+    permissions: "0644"
     owner: "root"
     content: |
-      aws_region   = "${log_group_region}"
-      log_group    = "${log_group_name}"
-  - path: "/etc/systemd/system/systemd-cloudwatch.service"
+      if $programname == 'concourse' then /var/log/concourse.log
+      if $programname == 'concourse' then ~
+  - path: "/var/awslogs/config/template.conf"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      [general]
+      state_file = /var/awslogs/state/agent-state
+
+      [/var/log/concourse.log]
+      file = /var/log/concourse.log
+      log_group_name = ${log_group_name}
+      log_stream_name = {instance_id}
+      datetime_format = %b %d %H:%M:%S
+  - path: "/etc/systemd/system/awslogs.service"
     permissions: "0644"
     owner: "root"
     content: |
       [Unit]
-      Description=Service for systemd-cloudwatch
-      Wants=basic.target
-      After=basic.target network.target
+      Description=Service for CloudWatch Logs agent
+      After=rc-local.service
 
       [Service]
+      Type=simple
       Restart=always
-      RestartSec=30s
       KillMode=process
-      ExecStart=/usr/local/bin/systemd-cloudwatch /usr/local/etc/systemd-cloudwatch-config
+      TimeoutSec=infinity
+      PIDFile=/var/awslogs/state/awslogs.pid
+      ExecStart=/var/awslogs/bin/awslogs-agent-launcher.sh --start --background --pidfile $PIDFILE --user awslogs --chuid awslogs &amp;
+
+      [Install]
+      WantedBy=multi-user.target
   - path: "/etc/systemd/system/concourse.service"
     permissions: "0644"
     owner: "root"
@@ -51,6 +68,10 @@ write_files:
       Restart=always
       RestartSec=30s
       TimeoutStartSec=5m
+      StandardOutput=syslog
+      StandardError=syslog
+      SyslogIdentifier=concourse
+
       Environment="CONCOURSE_GITHUB_AUTH_CLIENT_ID=${github_client_id}"
       Environment="CONCOURSE_GITHUB_AUTH_CLIENT_SECRET=${github_client_secret}"
       Environment="CONCOURSE_GITHUB_AUTH_USER=${github_users}"
@@ -72,13 +93,13 @@ write_files:
       WantedBy=multi-user.target
 runcmd:
   - |
-    curl -L "${systemd_cloudwatch_download_url}" > /usr/local/bin/systemd-cloudwatch
-    chmod 0755 /usr/local/bin/systemd-cloudwatch
-    chown root:root /usr/local/bin/systemd-cloudwatch
+    curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
+    chmod +x awslogs-agent-setup.py
+    ./awslogs-agent-setup.py --non-interactive --region ${log_group_region} --configfile=/var/awslogs/config/template.conf
   - |
     curl -L "${concourse_download_url}" > /usr/local/bin/concourse
     chmod 0755 /usr/local/bin/concourse
     chown root:root /usr/local/bin/concourse
   - |
-    systemctl enable systemd-cloudwatch.service --now
+    systemctl enable awslogs.service --now
     systemctl enable concourse.service --now

--- a/concourse/config/atc.yml
+++ b/concourse/config/atc.yml
@@ -1,4 +1,8 @@
 #cloud-config
+package_update: true
+packages:
+  - curl
+  - python
 write_files:
   - path: "/concourse/keys/web/tsa_host_key"
     permissions: "0644"
@@ -15,84 +19,66 @@ write_files:
     owner: "root"
     encoding: base64
     content: ${base64encode(authorized_worker_keys)}
-coreos:
-  update:
-    reboot-strategy: "reboot"
-  locksmith:
-    window-start: 02:00
-    window-length: 6h
-  units:
-   - name: cloudwatch-monitor.service
-     command: start
-     runtime: true
-     content: |
-       [Unit]
-       Description=Cloudwatch monitoring.
-       Documentation=https://github.com/a3linux/go-aws-mon/
-       Requires=docker.socket
-       After=docker.socket
-       [Service]
-       Type=oneshot
-       SyslogIdentifier=cloudwatch-monitor
-       ExecStartPre=-/usr/bin/docker kill cloudwatch-monitor
-       ExecStartPre=-/usr/bin/docker rm cloudwatch-monitor
-       ExecStartPre=/usr/bin/docker pull a3linux/go-aws-mon:latest
-       ExecStart=/usr/bin/docker run --name cloudwatch-monitor \
-                                     --volume=/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/certificates.crt \
-                                     --volume=/var/log:/var/log \
-                                     a3linux/go-aws-mon /usr/bin/go-aws-mon \
-                                     --mem-used \
-                                     --mem-avail \
-                                     --disk-space-used \
-                                     --disk-space-avail \
-                                     --disk-inode-util \
-                                     --disk-path=/,/var/lib
-   - name: cloudwatch-monitor.timer
-     enable: true
-     command: start
-     content: |
+  - path: "/usr/local/etc/systemd-cloudwatch-config"
+    owner: "root"
+    content: |
+      aws_region   = "${log_group_region}"
+      log_group    = "${log_group_name}"
+  - path: "/etc/systemd/system/systemd-cloudwatch.service"
+    permissions: "0644"
+    owner: "root"
+    content: |
       [Unit]
-      Description=Cloudwatch logging every minute.
-      [Timer]
-      OnBootSec=0m
-      OnCalendar=minutely
-   - name: concourse-web.service
-     command: start
-     runtime: true
-     content: |
-       [Unit]
-       Description=Concourse
-       Documentation=https://hub.docker.com/r/concourse/concourse/
-       Requires=docker.socket
-       After=docker.socket
-       [Service]
-       EnvironmentFile=/etc/environment
-       Restart=always
-       RestartSec=30s
-       TimeoutStartSec=5m
-       SyslogIdentifier=concourse-web
-       ExecStartPre=-/usr/bin/docker kill concourse-web
-       ExecStartPre=-/usr/bin/docker rm concourse-web
-       ExecStartPre=/usr/bin/docker pull ${image_repository}:${image_version}
-       ExecStart=/usr/bin/docker run --name concourse-web \
-                                     --volume=/var/run/docker.sock:/var/run/docker.sock \
-                                     --volume=/concourse/keys/web:/concourse-keys \
-                                     --publish=${atc_port}:8080 \
-                                     --publish=${tsa_port}:2222 \
-                                     --env=CONCOURSE_GITHUB_AUTH_CLIENT_ID=${github_client_id} \
-                                     --env=CONCOURSE_GITHUB_AUTH_CLIENT_SECRET=${github_client_secret} \
-                                     --env=CONCOURSE_GITHUB_AUTH_USER=${github_users} \
-                                     --env=CONCOURSE_POSTGRES_DATA_SOURCE=${concourse_postgres_source} \
-                                     --env=CONCOURSE_EXTERNAL_URL=${concourse_web_host} \
-                                     --env=CONCOURSE_PEER_URL=http://$${COREOS_PRIVATE_IPV4}:8080 \
-                                     --env=CONCOURSE_LOG_LEVEL=${log_level} \
-                                     --env=CONCOURSE_TSA_LOG_LEVEL=${log_level} \
-                                     --env=CONCOURSE_VAULT_URL=${vault_url} \
-                                     --env=CONCOURSE_VAULT_CLIENT_TOKEN=${vault_client_token} \
-                                     --env=CONCOURSE_ENCRYPTION_KEY=${encryption_key} \
-                                     --env=CONCOURSE_OLD_ENCRYPTION_KEY=${old_encryption_key} \
-                                     --log-driver=awslogs \
-                                     --log-opt awslogs-region=${log_group_region} \
-                                     --log-opt awslogs-group=${log_group_name} \
-                                     ${image_repository}:${image_version} \
-                                     web
+      Description=Service for systemd-cloudwatch
+      Wants=basic.target
+      After=basic.target network.target
+
+      [Service]
+      Restart=always
+      RestartSec=30s
+      KillMode=process
+      ExecStart=/usr/local/bin/systemd-cloudwatch /usr/local/etc/systemd-cloudwatch-config
+  - path: "/etc/systemd/system/concourse.service"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      [Unit]
+      Description=Service for Concourse ATC/TSA
+      Requires=network-online.target
+      After=network-online.target
+
+      [Service]
+      Restart=always
+      RestartSec=30s
+      TimeoutStartSec=5m
+      Environment="CONCOURSE_GITHUB_AUTH_CLIENT_ID=${github_client_id}"
+      Environment="CONCOURSE_GITHUB_AUTH_CLIENT_SECRET=${github_client_secret}"
+      Environment="CONCOURSE_GITHUB_AUTH_USER=${github_users}"
+      Environment="CONCOURSE_POSTGRES_DATA_SOURCE=${concourse_postgres_source}"
+      Environment="CONCOURSE_EXTERNAL_URL=${concourse_web_host}"
+      Environment="CONCOURSE_LOG_LEVEL=${log_level}"
+      Environment="CONCOURSE_TSA_LOG_LEVEL=${log_level}"
+      Environment="CONCOURSE_VAULT_URL=${vault_url}"
+      Environment="CONCOURSE_VAULT_CLIENT_TOKEN=${vault_client_token}"
+      Environment="CONCOURSE_TSA_HOST_KEY=/concourse/keys/web/tsa_host_key"
+      Environment="CONCOURSE_TSA_AUTHORIZED_KEYS=/concourse/keys/web/authorized_worker_keys"
+      Environment="CONCOURSE_SESSION_SIGNING_KEY=/concourse/keys/web/session_signing_key"
+      Environment="CONCOURSE_ENCRYPTION_KEY=${encryption_key}"
+      Environment="CONCOURSE_OLD_ENCRYPTION_KEY=${old_encryption_key}"
+      ExecStartPre=/bin/bash -c "/bin/systemctl set-environment CONCOURSE_PEER_URL=http://$(curl -L http://169.254.169.254/latest/meta-data/local-ipv4):8080"
+      ExecStart=/usr/local/bin/concourse web
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - |
+    curl -L "${systemd_cloudwatch_download_url}" > /usr/local/bin/systemd-cloudwatch
+    chmod 0755 /usr/local/bin/systemd-cloudwatch
+    chown root:root /usr/local/bin/systemd-cloudwatch
+  - |
+    curl -L "${concourse_download_url}" > /usr/local/bin/concourse
+    chmod 0755 /usr/local/bin/concourse
+    chown root:root /usr/local/bin/concourse
+  - |
+    systemctl enable systemd-cloudwatch.service --now
+    systemctl enable concourse.service --now

--- a/concourse/config/worker.yml
+++ b/concourse/config/worker.yml
@@ -1,4 +1,8 @@
 #cloud-config
+package_update: true
+packages:
+  - curl
+  - python
 write_files:
   - path: "/concourse/keys/worker/tsa_host_key.pub"
     permissions: "0644"
@@ -15,80 +19,80 @@ write_files:
     owner: "root"
     encoding: base64
     content: ${base64encode(pub_worker_key)}
-coreos:
-  update:
-    reboot-strategy: "reboot"
-  locksmith:
-    window-start: 02:00
-    window-length: 6h
-  units:
-   - name: cloudwatch-monitor.service
-     command: start
-     runtime: true
-     content: |
-       [Unit]
-       Description=Cloudwatch monitoring.
-       Documentation=https://github.com/a3linux/go-aws-mon/
-       Requires=docker.socket
-       After=docker.socket
-       [Service]
-       Type=oneshot
-       SyslogIdentifier=cloudwatch-monitor
-       ExecStartPre=-/usr/bin/docker kill cloudwatch-monitor
-       ExecStartPre=-/usr/bin/docker rm cloudwatch-monitor
-       ExecStartPre=/usr/bin/docker pull a3linux/go-aws-mon:latest
-       ExecStart=/usr/bin/docker run --name cloudwatch-monitor \
-                                     --volume=/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/certificates.crt \
-                                     --volume=/var/log:/var/log \
-                                     a3linux/go-aws-mon /usr/bin/go-aws-mon \
-                                     --mem-used \
-                                     --mem-avail \
-                                     --disk-space-used \
-                                     --disk-space-avail \
-                                     --disk-inode-util \
-                                     --disk-path=/,/var/lib
-   - name: cloudwatch-monitor.timer
-     enable: true
-     command: start
-     content: |
+  - path: "/etc/rsyslog.d/concourse.conf"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      if $programname == 'concourse' then /var/log/concourse.log
+      if $programname == 'concourse' then ~
+  - path: "/var/awslogs/config/template.conf"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      [general]
+      state_file = /var/awslogs/state/agent-state
+
+      [/var/log/concourse.log]
+      file = /var/log/concourse.log
+      log_group_name = ${log_group_name}
+      log_stream_name = {instance_id}
+      datetime_format = %b %d %H:%M:%S
+  - path: "/etc/systemd/system/awslogs.service"
+    permissions: "0644"
+    owner: "root"
+    content: |
       [Unit]
-      Description=Cloudwatch logging every minute.
-      [Timer]
-      OnBootSec=0m
-      OnCalendar=minutely
-   - name: concourse-worker.service
-     command: start
-     runtime: true
-     content: |
-       [Unit]
-       Description=Concourse
-       Documentation=https://hub.docker.com/r/concourse/concourse/
-       Requires=docker.socket
-       After=docker.socket
-       [Service]
-       EnvironmentFile=/etc/environment
-       Restart=always
-       RestartSec=30s
-       TimeoutStartSec=5m
-       SyslogIdentifier=concourse-worker
-       ExecStartPre=-/usr/bin/docker kill concourse-worker
-       ExecStartPre=-/usr/bin/docker rm concourse-worker
-       ExecStartPre=/usr/bin/docker pull ${image_repository}:${image_version}
-       ExecStart=/usr/bin/docker run --name concourse-worker \
-                                     --volume=/var/run/docker.sock:/var/run/docker.sock \
-                                     --volume=/concourse/keys/worker:/concourse-keys \
-                                     --volume=/concourse:/concourse \
-                                     --privileged \
-                                     --publish=7777:7777 \
-                                     --publish=7788:7788 \
-                                     --env=CONCOURSE_WORK_DIR=/concourse \
-                                     --env=CONCOURSE_TSA_HOST=${concourse_tsa_host} \
-                                     --env=CONCOURSE_PEER_IP=$${COREOS_PRIVATE_IPV4} \
-                                     --env=CONCOURSE_BIND_IP=0.0.0.0 \
-                                     --env=CONCOURSE_BAGGAGECLAIM_BIND_IP=0.0.0.0 \
-                                     --env=CONCOURSE_BAGGAGECLAIM_LOG_LEVEL=${log_level} \
-                                     --log-driver=awslogs \
-                                     --log-opt awslogs-region=${log_group_region} \
-                                     --log-opt awslogs-group=${log_group_name} \
-                                     ${image_repository}:${image_version} \
-                                     worker
+      Description=Service for CloudWatch Logs agent
+      After=rc-local.service
+
+      [Service]
+      Type=simple
+      Restart=always
+      KillMode=process
+      TimeoutSec=infinity
+      PIDFile=/var/awslogs/state/awslogs.pid
+      ExecStart=/var/awslogs/bin/awslogs-agent-launcher.sh --start --background --pidfile $PIDFILE --user awslogs --chuid awslogs &amp;
+
+      [Install]
+      WantedBy=multi-user.target
+  - path: "/etc/systemd/system/concourse.service"
+    permissions: "0644"
+    owner: "root"
+    content: |
+      [Unit]
+      Description=Service for Concourse ATC/TSA
+      Requires=network-online.target
+      After=network-online.target
+
+      [Service]
+      Restart=always
+      RestartSec=30s
+      TimeoutStartSec=5m
+      StandardOutput=syslog
+      StandardError=syslog
+      SyslogIdentifier=concourse
+
+      Environment="CONCOURSE_BIND_IP=0.0.0.0"
+      Environment="CONCOURSE_WORK_DIR=/concourse"
+      Environment="CONCOURSE_TSA_HOST=${concourse_tsa_host}"
+      Environment="CONCOURSE_BAGGAGECLAIM_BIND_IP=0.0.0.0"
+      Environment="CONCOURSE_BAGGAGECLAIM_LOG_LEVEL=${log_level}"
+      Environment="CONCOURSE_TSA_PUBLIC_KEY=/concourse/keys/worker/tsa_host_key.pub"
+      Environment="CONCOURSE_TSA_WORKER_PRIVATE_KEY=/concourse/keys/worker/worker_key"
+      ExecStartPre=/bin/bash -c "/bin/systemctl set-environment CONCOURSE_PEER_IP=$(curl -L http://169.254.169.254/latest/meta-data/local-ipv4)"
+      ExecStart=/usr/local/bin/concourse worker
+
+      [Install]
+      WantedBy=multi-user.target
+runcmd:
+  - |
+    curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
+    chmod +x awslogs-agent-setup.py
+    ./awslogs-agent-setup.py --non-interactive --region eu-west-1 --configfile=/var/awslogs/config/template.conf
+  - |
+    curl -L "${concourse_download_url}" > /usr/local/bin/concourse
+    chmod 0755 /usr/local/bin/concourse
+    chown root:root /usr/local/bin/concourse
+  - |
+    systemctl enable awslogs.service --now
+    systemctl enable concourse.service --now

--- a/concourse/config/worker.yml
+++ b/concourse/config/worker.yml
@@ -60,7 +60,7 @@ write_files:
     owner: "root"
     content: |
       [Unit]
-      Description=Service for Concourse ATC/TSA
+      Description=Service for Concourse Worker
       Requires=network-online.target
       After=network-online.target
 


### PR DESCRIPTION
Since the original plan was to run Concourse in a ECS cluster (which was not possible because the TSA/ATC run in the same container), the current implementation runs on CoreOS with concourse in a container. This has worked fine, but it's probably safer to run on a bare Ubuntu installation with the Concourse binary - which is what this PR implements.