### PR TITLE
Concourse AMI: AWS SSM agent is already stopped in latest image.

### DIFF
--- a/concourse/packer/template.json
+++ b/concourse/packer/template.json
@@ -23,7 +23,6 @@
             "sleep 30",
             "sudo yum update -y",
             "sudo yum install -y awslogs aws-cfn-bootstrap",
-            "sudo systemctl stop amazon-ssm-agent.service",
             "curl -L https://github.com/concourse/concourse/releases/download/{{user `concourse_version`}}/concourse_linux_amd64 -o concourse",
             "sudo chmod +x concourse",
             "sudo chown root:root concourse",


### PR DESCRIPTION
ami-03158b7a