### PR TITLE
Add desc to role

### DIFF
--- a/iam/role/example/example.tf
+++ b/iam/role/example/example.tf
@@ -12,9 +12,9 @@ module "developer" {
   ]
 }
 
-resource "aws_iam_role_policy_attachment" "view_only_policy" {
+resource "aws_iam_role_policy_attachment" "power_user_policy" {
   role       = "${module.developer.name}"
-  policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  policy_arn = "arn:aws:iam::aws:policy/job-function/PowerUserAccess"
 }
 
 output "url" {

--- a/iam/role/example/example.tf
+++ b/iam/role/example/example.tf
@@ -3,10 +3,10 @@ provider "aws" {
 }
 
 module "developer" {
-  source          = "github.com/TeliaSoneraNorge/divx-terraform-modules//iam/role"
-  prefix          = "example-project-developer"
-  trusted_account = "<user-account>"
-  role_description= "example role created to show iam/role module in use"
+  source           = "github.com/TeliaSoneraNorge/divx-terraform-modules//iam/role"
+  prefix           = "example-project-developer"
+  trusted_account  = "<user-account>"
+  role_description = "example role created to show iam/role module in use"
 
   users = [
     "first.last",

--- a/iam/role/example/example.tf
+++ b/iam/role/example/example.tf
@@ -6,6 +6,7 @@ module "developer" {
   source          = "github.com/TeliaSoneraNorge/divx-terraform-modules//iam/role"
   prefix          = "example-project-developer"
   trusted_account = "<user-account>"
+  role_description= "example role created to show iam/role module in use"
 
   users = [
     "first.last",
@@ -14,7 +15,7 @@ module "developer" {
 
 resource "aws_iam_role_policy_attachment" "power_user_policy" {
   role       = "${module.developer.name}"
-  policy_arn = "arn:aws:iam::aws:policy/job-function/PowerUserAccess"
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
 
 output "url" {

--- a/iam/role/role.tf
+++ b/iam/role/role.tf
@@ -19,6 +19,11 @@ variable "users" {
   description = "List of users in the trusted account which will be allowed to assume this role."
 }
 
+variable "role_description" {
+  description = "A description to add to the role"
+  default = "Terraform created role"
+}
+
 # ------------------------------------------------------------------------------
 # Resources
 # ------------------------------------------------------------------------------
@@ -28,6 +33,7 @@ resource "aws_iam_role" "main" {
   name                  = "${var.prefix}-role"
   assume_role_policy    = "${data.aws_iam_policy_document.assume.json}"
   force_detach_policies = "true"
+  description = "${var.role_description}"
 }
 
 data "aws_iam_policy_document" "assume" {

--- a/iam/role/role.tf
+++ b/iam/role/role.tf
@@ -21,7 +21,7 @@ variable "users" {
 
 variable "role_description" {
   description = "A description to add to the role"
-  default = "Terraform created role"
+  default     = "Terraform created role"
 }
 
 # ------------------------------------------------------------------------------
@@ -33,7 +33,7 @@ resource "aws_iam_role" "main" {
   name                  = "${var.prefix}-role"
   assume_role_policy    = "${data.aws_iam_policy_document.assume.json}"
   force_detach_policies = "true"
-  description = "${var.role_description}"
+  description           = "${var.role_description}"
 }
 
 data "aws_iam_policy_document" "assume" {


### PR DESCRIPTION
Added a description to a role module to help identify what the role is for in console.
Updated example to add a policy that was not already implicitly added by module