### PR TITLE
Remove length function

### DIFF
--- a/ecs/cluster/main.tf
+++ b/ecs/cluster/main.tf
@@ -81,7 +81,7 @@ module "asg" {
 }
 
 resource "aws_security_group_rule" "ingress" {
-  count                    = "${length(var.load_balancer_count)}"
+  count                    = "${var.load_balancer_count}"
   security_group_id        = "${module.asg.security_group_id}"
   type                     = "ingress"
   protocol                 = "tcp"


### PR DESCRIPTION
I believe this is mistake since `length` function takes the argument and count the characters inside the input variable. Therefore whatever `var.load_balancer_count` have inside, it is always going to be at least 1 after applying `length` function (depending on string size of number). I have removed the function.

Also, wasn't the first intention something like this?
```
count                    = "${length(var.load_balancers)}"
```
